### PR TITLE
HEP Refactor

### DIFF
--- a/lib/outputs/output_hep.js
+++ b/lib/outputs/output_hep.js
@@ -1,6 +1,7 @@
 var abstract_udp = require('./abstract_udp'),
   hepjs = require('hep-js'),
-  util = require('util');
+  util = require('util'),
+  logger = require('log4node');
 
 function OutputHep() {
   abstract_udp.AbstractUdp.call(this);
@@ -10,7 +11,7 @@ function OutputHep() {
   this.mergeConfig(this.serializer_config());
   this.mergeConfig({
     name: 'HEP/EEP Server',
-    optional_params: ['hep_id', 'hep_pass', 'hep_cid', 'hep_type'],
+    optional_params: ['hep_id', 'hep_pass', 'hep_cid', 'hep_type', 'src_ip', 'src_port', 'dst_ip', 'dst_port', 'hep_payload_type', 'hep_ip_family', 'hep_protocol'],
     default_values: {
       host: '127.0.0.1',
       port: 9063,
@@ -18,6 +19,14 @@ function OutputHep() {
       hep_pass: 'MyHep',
       hep_cid: '#{correlation_id}',
       hep_type: 1,
+      hep_payload_type: 1,
+      hep_ip_family: 1,
+      hep_protocol: 17,
+      src_ip: '127.0.0.1',
+      src_port: '0',
+      dst_ip: '127.0.0.2',
+      dst_port: '0',
+      hep_timefield: false
     },
   });
 }
@@ -29,14 +38,13 @@ OutputHep.prototype.preHep = function(data) {
   try {
 	  // IF HEP JSON
 	  if (data.rcinfo && data.payload) {
-		console.log('PRE-PACKED HEP JSON!');
+		logger.debug('PRE-PACKED HEP JSON!');
 		data.rcinfo.captureId = this.hep_id;
 		data.rcinfo.capturePass = this.hep_pass;
 		return hepjs.encapsulate(data.payload,data.rcinfo);
 	  }
 
-	  // Default to static type
-
+	  // Default HEP RCINFO
 	  var hep_proto = {
 	    'type': 'HEP',
 	    'version': 3,
@@ -44,37 +52,34 @@ OutputHep.prototype.preHep = function(data) {
 	    'proto_type': this.hep_type ? this.hep_type : 100,
 	    'captureId': this.hep_id ? this.hep_id : 2001,
 	    'capturePass': this.hep_pass ? this.hep_pass : 'paStash',
-	    'ip_family': 2,
-	    'protocol': 17
+	    'ip_family': this.hep_ip_family,
+	    'protocol': this.hep_protocol
 	  };
 
   	var datenow = (new Date()).getTime();
 	hep_proto.time_sec = Math.floor(datenow / 1000);
 	hep_proto.time_usec = datenow - (hep_proto.time_sec * 1000);
 	// Build HEP3 w/ null network parameters - TBD configurable
-  	hep_proto.srcIp = data.srcIp ? data.srcIp : '127.0.0.1';
-  	hep_proto.dstIp = data.dstIp ? data.dstIp : '127.0.0.1';
-  	hep_proto.srcPort = data.srcPort ? data.srcPort : 0;
-  	hep_proto.dstPort = data.dstPort ? data.dstPort : 0;
+  	hep_proto.srcIp = data.srcIp || this.src_ip;
+  	hep_proto.dstIp = data.dstIp || this.dst_ip;
+  	hep_proto.srcPort = data.srcPort || this.src_port;
+  	hep_proto.dstPort = data.dstPort || this.dst_port;
   	// pair correlation id from pattern
-	hep_proto.correlation_id = data.correlation_id ? data.correlation_id : '';
+	hep_proto.correlation_id = data.correlation_id || '';
 
-	// console.log('RCINFO:',hep_proto,data);
-
-	if (hep_proto.correlation_id !== '') {
+	if (data.payload) {
 	    // Pack HEP3
 	    return hepjs.encapsulate(data.payload,hep_proto);
  	} else {
-
+	    // Pack HEP3 Log Type fallback
 	    hep_proto.payload_type = 100;
-	    return hepjs.encapsulate(data.payload,hep_proto);
+	    return hepjs.encapsulate(data,hep_proto);
         }
 
-   } catch(e) { console.log('PREHEP ERROR:',e); }
+   } catch(e) { logger.error('PREHEP ERROR:',e); }
 };
 
 OutputHep.prototype.formatPayload = function(data, callback) {
-  //  callback(this.serialize_data(this.preHep(data)));
   if (data) callback(this.preHep(data));
 };
 

--- a/lib/outputs/output_hep.js
+++ b/lib/outputs/output_hep.js
@@ -18,7 +18,7 @@ function OutputHep() {
       hep_id: '2001',
       hep_pass: 'MyHep',
       hep_cid: '#{correlation_id}',
-      hep_type: 1,
+      hep_type: 100,
       hep_payload_type: 1,
       hep_ip_family: 1,
       hep_protocol: 17,
@@ -42,16 +42,16 @@ OutputHep.prototype.preHep = function(data) {
 		data.rcinfo.captureId = this.hep_id;
 		data.rcinfo.capturePass = this.hep_pass;
 		return hepjs.encapsulate(data.payload,data.rcinfo);
-	  }
+	  };
 
 	  // Default HEP RCINFO
 	  var hep_proto = {
 	    'type': 'HEP',
 	    'version': 3,
-	    'payload_type': 1,
-	    'proto_type': this.hep_type ? this.hep_type : 100,
-	    'captureId': this.hep_id ? this.hep_id : 2001,
-	    'capturePass': this.hep_pass ? this.hep_pass : 'paStash',
+	    'payload_type': this.hep_payload_type,
+	    'proto_type': this.hep_type,
+	    'captureId': this.hep_id,
+	    'capturePass': this.hep_pass,
 	    'ip_family': this.hep_ip_family,
 	    'protocol': this.hep_protocol
 	  };
@@ -69,11 +69,11 @@ OutputHep.prototype.preHep = function(data) {
 
 	if (data.payload) {
 	    // Pack HEP3
-	    return hepjs.encapsulate(data.payload,hep_proto);
+	    return hepjs.encapsulate(JSON.stringify(data.payload),hep_proto);
  	} else {
 	    // Pack HEP3 Log Type fallback
 	    hep_proto.payload_type = 100;
-	    return hepjs.encapsulate(data,hep_proto);
+	    return hepjs.encapsulate(JSON.stringify(data),hep_proto);
         }
 
    } catch(e) { logger.error('PREHEP ERROR:',e); }


### PR DESCRIPTION
Refactor HEP output module to handle JSON logs easily and implement more dynamic options.

HEP data can be provided "preset" with existing RCINFO and PAYLOAD objects for pass-through HEP delivery with minimal processing. Optional PAYLOAD object can be created with mustache to create specific formats, extracting desired fields/elements for output. When no PAYLOAD object is found, the remaining HEP parameters are processed and Log Type 100 is used as a final fallback.