### PR TITLE
NSQ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Outputs
 * [Logio](docs/outputs/logio.md)
 * [TCP / TLS](docs/outputs/tcp_tls.md)
 * [AMQP](docs/outputs/amqp.md)
+* [NSQ](docs/outputs/nsq.md)
 * [SQS](docs/outputs/sqs.md)
 * [HEP](docs/outputs/hep.md)
 

--- a/docs/inputs/nsq.md
+++ b/docs/inputs/nsq.md
@@ -1,0 +1,24 @@
+NSQ input plugin
+---
+
+Status : experimental plugin.
+
+This plugin is used to connect a paStash Input to an NSQ Server Topic/Channel.
+
+Config using logstash format:
+````
+input {
+  nsq {
+    host => '127.0.0.1'
+    port => 4561
+    topic => 'some_topic'
+    channel => 'some_channel'
+  }
+}
+````
+
+Parameters :
+* ``host``: Hostname or IP of NSQ Server.
+* ``port``: Service Port of NSQ Server.
+* ``topic``: NSQ Topic.
+* ``channel``: NSQ Channel.

--- a/docs/outputs/nsq.md
+++ b/docs/outputs/nsq.md
@@ -1,0 +1,26 @@
+NSQ output plugin
+---
+
+Status : experimental plugin, unit tested and maintained.
+
+This plugin is used to ship events via NSQ Topics.
+
+
+Config using logstash format:
+````
+output {
+  nsq {
+    topic => "your-topic-here"
+    dataUrl => "127.0.0.1"
+  }
+}
+````
+
+Parameters :
+* ``dataUrl``: NSQ Data Url. Default: 'localhost'
+* ``dataHttpPort``: NSQ Data HTTP port. Default: 4151
+* ``dataTcpPort``: NSQ TCP port. Default: 4150
+* ``topic``: NSQ Topic. Default: 'test-topic'
+* ``protocol``: NSQ Protocol type. Default: 'http'
+* ``autoCreate``: Auto-Create Topics. Default: false
+* ``debug``: Debug option. Optional.

--- a/docs/outputs/nsq.md
+++ b/docs/outputs/nsq.md
@@ -18,9 +18,6 @@ output {
 
 Parameters :
 * ``dataUrl``: NSQ Data Url. Default: 'localhost'
-* ``dataHttpPort``: NSQ Data HTTP port. Default: 4151
 * ``dataTcpPort``: NSQ TCP port. Default: 4150
 * ``topic``: NSQ Topic. Default: 'test-topic'
-* ``protocol``: NSQ Protocol type. Default: 'http'
-* ``autoCreate``: Auto-Create Topics. Default: false
 * ``debug``: Debug option. Optional.

--- a/lib/inputs/input_nsq.js
+++ b/lib/inputs/input_nsq.js
@@ -1,0 +1,51 @@
+var base_input = require('../lib/base_input'),
+  util = require('util'),
+  logger = require('log4node');
+
+var nsq = require('nsqjs');
+
+function InputNsq() {
+  base_input.BaseInput.call(this);
+  this.mergeConfig(this.unserializer_config());
+  this.mergeConfig(ssl_helper.config());
+  this.mergeConfig({
+    name: 'NSQ',
+    host_field: 'host',
+    port_field: 'port',
+    required_params: ['channel', 'topic'],
+    optional_params: ['durable', 'debug'],
+    default_values: {
+      'durable': true,
+      'debug': false,
+    },
+    start_hook: this.start,
+  });
+}
+
+util.inherits(InputNsq, base_input.BaseInput);
+
+InputNsq.prototype.start = function(callback) {
+
+  logger.info('Start NSQ listener', 'channel', this.channel, 'topic', this.topic);
+
+	const reader = new nsq.Reader(this.topic, this.channel, {
+	  lookupdHTTPAddresses: this.host+':'+this.port
+	});
+	reader.connect();
+	reader.on('message', msg => {
+	    logger.debug('Received message [%s]: %s', msg.id, msg.body.toString());
+	    msg.finish();
+	    this.emit('data', msg);
+	}.bind(this));
+
+  callback();
+};
+
+InputNsq.prototype.close = function(callback) {
+  logger.info('Closing NSQ input', this.amqp_url, 'exchange ' + this.exchange_name);
+
+};
+
+exports.create = function() {
+  return new InputNsq();
+};

--- a/lib/inputs/input_nsq.js
+++ b/lib/inputs/input_nsq.js
@@ -7,7 +7,6 @@ var nsq = require('nsqjs');
 function InputNsq() {
   base_input.BaseInput.call(this);
   this.mergeConfig(this.unserializer_config());
-  this.mergeConfig(ssl_helper.config());
   this.mergeConfig({
     name: 'NSQ',
     host_field: 'host',
@@ -16,7 +15,7 @@ function InputNsq() {
     optional_params: ['durable', 'debug'],
     default_values: {
       'durable': true,
-      'debug': false,
+      'debug': false
     },
     start_hook: this.start,
   });
@@ -26,8 +25,9 @@ util.inherits(InputNsq, base_input.BaseInput);
 
 InputNsq.prototype.start = function(callback) {
 
-  logger.info('Start NSQ listener', 'channel', this.channel, 'topic', this.topic);
+  logger.info('Start NSQ listener', 'channel:' + this.channel, 'topic:' + this.topic);
 
+	var emit = this.emit;
 	const reader = new nsq.Reader(this.topic, this.channel, {
 	  lookupdHTTPAddresses: this.host+':'+this.port
 	});
@@ -36,14 +36,14 @@ InputNsq.prototype.start = function(callback) {
 	    logger.debug('Received message [%s]: %s', msg.id, msg.body.toString());
 	    msg.finish();
 	    this.emit('data', msg);
-	}.bind(this));
+	});
 
   callback();
 };
 
 InputNsq.prototype.close = function(callback) {
-  logger.info('Closing NSQ input', this.amqp_url, 'exchange ' + this.exchange_name);
-
+  logger.info('Closing NSQ input', 'topic: ' + this.topic, 'channel: ' + this.channel);
+  callback();
 };
 
 exports.create = function() {

--- a/lib/outputs/output_nsq.js
+++ b/lib/outputs/output_nsq.js
@@ -1,0 +1,70 @@
+var base_output = require('../lib/base_output'),
+  util = require('util'),
+  logger = require('log4node');
+
+var Publisher = require('nsq-publisher');
+
+function OutputNsq() {
+  base_output.BaseOutput.call(this);
+  this.mergeConfig(this.serializer_config('json_logstash'));
+  this.mergeConfig({
+    name: 'NSQ',
+    optional_params: ['protocol', 'topic', 'dataUrl', 'dataHttpPort', 'dataTcpPort', 'autoCreate', 'debug' ],
+    default_values: {
+	debug: false,
+	autoCreate: true,
+	protocol: 'http',
+	dataUrl: 'localhost',
+	topic: 'hepic'
+    },
+    start_hook: this.start,
+  });
+}
+
+util.inherits(OutputNsq, base_output.BaseOutput);
+
+OutputNsq.prototype.start = function(callback) {
+
+  if(!this.topic||this.dataUrl) return;
+
+  logger.info('Initializing NSQ Publisher...');
+  this.pub = new Publisher({
+  	dataUrl: this.dataUrl, // optional
+  	dataHttpPort: this.dataHttpPort || 4151, // optional
+  	dataTcpPort: this.dataTcpPort || 4150, // optional
+  	topic: this.topic, 
+  	protocol: this.protocol, // optional
+  	autoCreate: this.autoCreate // optional
+  });
+  logger.info('Initializing NSQ Topic', this.topic);
+  pub.createTopic(function (err) {
+    if (err) {
+  	logger.error(err);
+	return;
+    } else {
+  	logger.info('NSQ Publisher initialized!');
+    }
+  });
+
+  callback();
+};
+
+OutputNsq.prototype.process = function(data) {
+
+	this.pub.publish(data, function (err) {
+	  if (err) {
+	  	logger.error(err);
+	  } else {
+	  	logger.debug('NSQ message published');
+	  }
+	});
+};
+
+OutputNsq.prototype.close = function(callback) {
+  logger.info('Closing NSQ Output for Topic', this.topic);
+  callback();
+};
+
+exports.create = function() {
+  return new OutputNsq();
+};

--- a/lib/outputs/output_nsq.js
+++ b/lib/outputs/output_nsq.js
@@ -9,9 +9,11 @@ function OutputNsq() {
   this.mergeConfig(this.serializer_config('json_logstash'));
   this.mergeConfig({
     name: 'NSQ',
-    optional_params: ['topic', 'dataUrl', 'dataTcpPort', 'debug' ],
+    optional_params: ['topic', 'dataUrl', 'dataTcpPort', 'debug', 'timeout', 'retries' ],
     default_values: {
 	debug: false,
+	timeout: 5000,
+	retries: 10,
 	dataTcpPort: 4150,
 	dataUrl: 'localhost',
 	topic: 'hepic'
@@ -28,6 +30,8 @@ OutputNsq.prototype.start = function(callback) {
   logger.info('Initializing NSQ Publisher...');
 
   const w = new nsq.Writer(this.dataUrl, this.dataTcpPort);
+  var count = 0;
+
   w.connect();
   w.on('ready', () => {
     logger.info('NSQ Writer Ready!');
@@ -36,6 +40,12 @@ OutputNsq.prototype.start = function(callback) {
 
   w.on('closed', () => {
     logger.error('NSQ Writer closed!');
+    if (count < this.retries) {
+	    logger.info('Reconnecting in '+this.timeout+'');
+	    setTimeout(function(){ w.connect(); }, this.timeout);
+    } else {
+	logger.error('Giving up! Attempted:',this.retries);
+   }
   });
 
   callback();
@@ -47,7 +57,6 @@ OutputNsq.prototype.process = function(data) {
 	    if (err) { logger.error(err.message); }
 	    logger.debug('NSQ Message sent successfully!');
 	});
-	return;
 };
 
 OutputNsq.prototype.close = function(callback) {

--- a/lib/outputs/output_nsq.js
+++ b/lib/outputs/output_nsq.js
@@ -2,18 +2,17 @@ var base_output = require('../lib/base_output'),
   util = require('util'),
   logger = require('log4node');
 
-var Publisher = require('nsq-publisher');
+var nsq = require('nsqjs');
 
 function OutputNsq() {
   base_output.BaseOutput.call(this);
   this.mergeConfig(this.serializer_config('json_logstash'));
   this.mergeConfig({
     name: 'NSQ',
-    optional_params: ['protocol', 'topic', 'dataUrl', 'dataHttpPort', 'dataTcpPort', 'autoCreate', 'debug' ],
+    optional_params: ['topic', 'dataUrl', 'dataTcpPort', 'debug' ],
     default_values: {
 	debug: false,
-	autoCreate: true,
-	protocol: 'http',
+	dataTcpPort: 4150,
 	dataUrl: 'localhost',
 	topic: 'hepic'
     },
@@ -25,25 +24,18 @@ util.inherits(OutputNsq, base_output.BaseOutput);
 
 OutputNsq.prototype.start = function(callback) {
 
-  if(!this.topic||this.dataUrl) return;
-
+  if (!this.topic||!this.dataUrl) { logger.error('Critical Error! Missing config!'); return; }
   logger.info('Initializing NSQ Publisher...');
-  this.pub = new Publisher({
-  	dataUrl: this.dataUrl, // optional
-  	dataHttpPort: this.dataHttpPort || 4151, // optional
-  	dataTcpPort: this.dataTcpPort || 4150, // optional
-  	topic: this.topic, 
-  	protocol: this.protocol, // optional
-  	autoCreate: this.autoCreate // optional
+
+  const w = new nsq.Writer(this.dataUrl, this.dataTcpPort);
+  w.connect();
+  w.on('ready', () => {
+    logger.info('NSQ Writer Ready!');
+    this.nsqw = w;
   });
-  logger.info('Initializing NSQ Topic', this.topic);
-  pub.createTopic(function (err) {
-    if (err) {
-  	logger.error(err);
-	return;
-    } else {
-  	logger.info('NSQ Publisher initialized!');
-    }
+
+  w.on('closed', () => {
+    logger.error('NSQ Writer closed!');
   });
 
   callback();
@@ -51,17 +43,16 @@ OutputNsq.prototype.start = function(callback) {
 
 OutputNsq.prototype.process = function(data) {
 
-	this.pub.publish(data, function (err) {
-	  if (err) {
-	  	logger.error(err);
-	  } else {
-	  	logger.debug('NSQ message published');
-	  }
+	this.nsqw.publish(this.topic, JSON.stringify(data),  err => {
+	    if (err) { logger.error(err.message); }
+	    logger.debug('NSQ Message sent successfully!');
 	});
+	return;
 };
 
 OutputNsq.prototype.close = function(callback) {
   logger.info('Closing NSQ Output for Topic', this.topic);
+  // this.nsqw.close();
   callback();
 };
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,27 @@
   "version": "0.1.5",
   "originator": "Bertrand Paquet <bertrand.paquet@gmail.com>",
   "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com>",
-  "keywords": ["logstash","log","zmq","zeromq","hep","eep","freeswitch","asterisk","avaya","janus","homer","hepic","splunk","bencode","redis","cep","elasticsearch","beats","netflow"],
+  "keywords": [
+    "logstash",
+    "log",
+    "zmq",
+    "zeromq",
+    "hep",
+    "eep",
+    "freeswitch",
+    "asterisk",
+    "avaya",
+    "janus",
+    "homer",
+    "hepic",
+    "splunk",
+    "bencode",
+    "redis",
+    "cep",
+    "elasticsearch",
+    "beats",
+    "netflow"
+  ],
   "main": "./lib/log4node.js",
   "homepage": "https://github.com/sipcapture/pastash",
   "repository": {
@@ -26,13 +46,14 @@
     "test": "./test-runner.sh"
   },
   "dependencies": {
-    "log4node": "0.1.6",
-    "optimist": "0.6.1",
-    "mkdirp": "0.5.1",
     "async": "2.5.0",
-    "lru-cache": "4.1.x"
+    "log4node": "0.1.6",
+    "lru-cache": "4.1.x",
+    "mkdirp": "0.5.1",
+    "nsq-publisher": "^1.0.3",
+    "optimist": "0.6.1"
   },
-  "optionalDependencies":{
+  "optionalDependencies": {
     "gun": "0.8.7",
     "kafka-node": "2.2.3",
     "aws-sdk": "2.112.x",
@@ -42,7 +63,7 @@
     "modesl": "*",
     "node-sflow": "*",
     "asterisk.io": "git+https://git@github.com/lmangani/asterisk.io.git",
-    "moment": "2.9.0",
+    "moment": "2.18.1",
     "redis": "2.8.0",
     "ws": "3.1.0",
     "oniguruma": "7.0.x",
@@ -55,7 +76,6 @@
     "lumberjack-protocol": "git://github.com/bpaquet/node-lumberjack-protocol.git",
     "hep-js": "*",
     "node-netflowv9": "*",
-    "moment": "2.18.1",
     "sqlite3": "3.1.10",
     "splunk-logging": "0.9.3",
     "mustache": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "log4node": "0.1.6",
     "lru-cache": "4.1.x",
     "mkdirp": "0.5.1",
-    "nsq-publisher": "^1.0.3",
+    "nsqjs": "^0.10.0",
     "optimist": "0.6.1"
   },
   "optionalDependencies": {


### PR DESCRIPTION
PR implements 

```output/nsq```: basic support for publishing topics to NSQ servers via output module (tested)
```input/nsq```: basic support for pulling NSQ topics/channels via input module (untested)