### PR TITLE
Added missing json parsing

### DIFF
--- a/lib/outputs/output_kafka.js
+++ b/lib/outputs/output_kafka.js
@@ -14,12 +14,10 @@ function OutputKafka() {
   this.mergeConfig(this.serializer_config('json_logstash'));
   this.mergeConfig({
     name: 'Kafka',
-    optional_params: ['kafkaHost', 'topic', 'partition', 'partition_default', 'threshold_down', 'check_interval', 'debug' ],
+    optional_params: ['kafkaHost', 'topic', 'partition', 'threshold_down', 'check_interval', 'debug' ],
     default_values: {
-	debug: false,
-	topic: 'hepic',
-	partition_default: 'hepic',
-	threshold_down: 10
+      debug: false,
+      threshold_down: 10
     },
     start_hook: this.start,
   });
@@ -34,8 +32,8 @@ OutputKafka.prototype.start = function(callback) {
   var client = new kafka.KafkaClient({ kafkaHost: this.kafkaHost });
   var Producer = kafka.Producer;
   var options = {};
-  if (this.partition) {  
-    var options = { partitionerType: Producer.PARTITIONER_TYPES["keyed"] };
+  if (this.partition) {
+    options = { partitionerType: Producer.PARTITIONER_TYPES["keyed"] };
   }
   this.producer = new Producer(client,options);
   this.producer.on('error', (err) => {
@@ -46,17 +44,17 @@ OutputKafka.prototype.start = function(callback) {
     console.log('Kafka Client Ready!');
     this.error_count = 0;
   });
-	
+
   if (this.check_interval) {
     if (this.check_interval < 1000) this.check_interval = 1000;
     logger.info('Kafka Check timer every ' + this.check_interval + 'ms');
     this.check_interval_id = setInterval(function() {
       this.check();
     }.bind(this), this.check_interval);
-  }	
+  }
   this.on_alarm = false;
   this.error_count = 0;
-	
+
   logger.info('Creating Kafka Output to', this.kafkaHost);
   callback();
 };
@@ -76,28 +74,37 @@ OutputKafka.prototype.check = function() {
 };
 
 OutputKafka.prototype.process = function(data) {
-		
-	var d = [{ topic: this.topic, messages: JSON.stringify(data) }];
-	try {
-	  if (this.partition) {
-	    if (data.message && data.message[this.partition]) {
-	      d[0].key = data.message[this.partition];
-	    }
-	  }
-	  if (this.debug) logger.info("Preparing to send to Kafka", d[0] );
-	  this.producer.send(d, function(err, result) {
-		if (err) {
-		  logger.warning("Kafka Producer Error:", err);
-		  this.error_count++;
-		  if (this.error_count > this.threshold_down){
-		    this.on_alarm = true;
-		    this.emit('alarm', true, this.kafkaHost);
-		  }
-		}
-		if (this.error_count > 0) this.error_count--;
-		if (this.debug) logger.info("Response from Kafka:", result);
-	  });		
-	} catch (e) { logger.error(e); }
+
+  var d = [{ topic: this.topic, messages: JSON.stringify(data) }];
+
+  try {
+    if (this.partition && data.message) {
+      var json_msg = JSON.parse(data.message);
+      d[0].key = json_msg[this.partition];
+    }
+  } catch (e) {
+    if (this.debug) logger.info("No value found for partition key", this.partition );
+  }
+
+  if (this.debug) logger.info("Preparing to send to Kafka\n", d[0], "\n\n" );
+
+  try {
+    this.producer.send(d, function(err, result) {
+      if (err) {
+        logger.warning("Kafka Producer Error:", err);
+        this.error_count++;
+        if (this.error_count > this.threshold_down){
+          this.on_alarm = true;
+          this.emit('alarm', true, this.kafkaHost);
+        }
+      }
+      if (this.error_count > 0) this.error_count--;
+      if (this.debug) logger.info("Response from Kafka:", result);
+    });
+  } catch (e) {
+    logger.error(e);
+  }
+
 };
 
 OutputKafka.prototype.close = function(callback) {


### PR DESCRIPTION
The most important fix was that `data.message` needed to be run through `JSON.parse` before we could identify the partition key.  Otherwise made a few other minor changes:

- `partition_default` didn't seem necessary
- default value for `topic` also didn't seem relevant
- separate try / catch blocks around finding partition key and sending to Kafka