### PR TITLE
Pipeline Cache Aggregation filter

### DIFF
--- a/docs/filters/cacheloop.md
+++ b/docs/filters/cacheloop.md
@@ -1,0 +1,24 @@
+Cacheloop filter
+---
+
+Status : core plugin, unit tested and maintained.
+
+The CacheLoop filter provides aggregation features within a pipeline implemented as an LRU collecting same key objects and emitting groups upon expiration or eviction.
+
+Example: aggregate documents with the same 'correlation_id' keys in a 5s range.
+````
+filter {
+  cacheloop {
+    maxAge: 5000
+    extract => correlation_id
+    bypass => false
+  }
+}
+`````
+
+Parameters:
+
+* ``extract``: which field to work on for grouping. Mandatory.
+* ``cacheSize``: maximum size for records before eviction. Default: 5000
+* ``cacheAge``: maximum age for records in cache in millisecods. Default: 10000
+* ``bypass``:Let records pass through, causing duplication. Default: false

--- a/docs/filters/cacheloop.md
+++ b/docs/filters/cacheloop.md
@@ -11,8 +11,9 @@ filter {
   if [status] == 10 {
     cacheloop {
       cacheAge: 5000
-      extract => correlation_id
+      extract => 'correlation_id'
       bypass => false
+      custom_type => 'unified'
     }
   }
 }
@@ -23,4 +24,5 @@ Parameters:
 * ``extract``: which field to work on for grouping. Mandatory.
 * ``cacheSize``: maximum size for records before eviction. Default: 5000
 * ``cacheAge``: maximum age for records in cache in millisecods. Default: 10000
-* ``bypass``:Let records pass through, causing duplication. Default: false
+* ``bypass``:Let records pass through other pipes, causing duplication. Default: false
+* ``custom_type``: inject a custom 'type' tag in output. Default: false.

--- a/docs/filters/cacheloop.md
+++ b/docs/filters/cacheloop.md
@@ -10,7 +10,7 @@ Example: aggregate documents with the same 'correlation_id' keys in a 5s range.
 filter {
   if [status] == 10 {
     cacheloop {
-      maxAge: 5000
+      cacheAge: 5000
       extract => correlation_id
       bypass => false
     }

--- a/docs/filters/cacheloop.md
+++ b/docs/filters/cacheloop.md
@@ -8,10 +8,12 @@ The CacheLoop filter provides aggregation features within a pipeline implemented
 Example: aggregate documents with the same 'correlation_id' keys in a 5s range.
 ````
 filter {
-  cacheloop {
-    maxAge: 5000
-    extract => correlation_id
-    bypass => false
+  if [status] == 10 {
+    cacheloop {
+      maxAge: 5000
+      extract => correlation_id
+      bypass => false
+    }
   }
 }
 `````

--- a/lib/filters/filter_cacheloop.js
+++ b/lib/filters/filter_cacheloop.js
@@ -32,6 +32,7 @@ FilterCacheloop.prototype.start = function(callback) {
       });
       if (records.length == 0||!records.length) return;
       output[key] = records;
+      output[this.extract] = key;
       this.emit('output',output);
     }
   }.bind(this);

--- a/lib/filters/filter_cacheloop.js
+++ b/lib/filters/filter_cacheloop.js
@@ -8,12 +8,13 @@ function FilterCacheloop() {
   base_filter.BaseFilter.call(this);
   this.mergeConfig({
     name: 'CacheLoop',
-    optional_params: ['cacheSize','cacheAge','extract','groupBy','mean','bypass'],
+    optional_params: ['cacheSize','cacheAge','extract','groupBy','mean','bypass','custom_type'],
     default_values: {
       'cacheSize': 5000,
       'cacheAge': 10000,
       'extract': 'correlation_id',
       'bypass': true,
+      'custom_type': false
     },
     start_hook: this.start,
   });
@@ -33,6 +34,7 @@ FilterCacheloop.prototype.start = function(callback) {
       if (records.length == 0||!records.length) return;
       output[key] = records;
       output[this.extract] = key;
+      if(this.custom_type) output['type'] = this.custom_type;
       this.emit('output',output);
     }
   }.bind(this);

--- a/lib/filters/filter_cacheloop.js
+++ b/lib/filters/filter_cacheloop.js
@@ -1,0 +1,56 @@
+var base_filter = require('../lib/base_filter'),
+  util = require('util'),
+  logger = require('log4node');
+
+var recordCache = require('record-cache');
+
+function FilterCacheloop() {
+  base_filter.BaseFilter.call(this);
+  this.mergeConfig({
+    name: 'CacheLoop',
+    optional_params: ['cacheSize','cacheAge','extract'],
+    default_values: {
+      'cacheSize': 5000,
+      'cacheAge': 10000,
+      'extract': 'correlation_id',
+      'bypass': false
+    },
+    start_hook: this.start,
+  });
+}
+
+util.inherits(FilterCacheloop, base_filter.BaseFilter);
+
+FilterCacheloop.prototype.start = function(callback) {
+  logger.info('Initialized Drop Filter');
+  this.onStale = function(data){
+    for (let [key, value] of data.records.entries()) {
+      var records = []; var output = {};
+      value.list.forEach(function(row){
+        records.push(row.record);
+      });
+      if (records.length == 0||!records.length) return;
+      output[key] = records;
+      this.emit('data',output);
+    }
+  }.bind(this);
+
+  this.cache = recordCache({
+    maxSize: this.cacheSize,
+    maxAge: this.cacheAge,
+    onStale: this.onStale
+  }.bind(this));
+
+  callback();
+};
+
+FilterCacheloop.prototype.process = function(data) {
+  // cache by extraction
+  if (data[this.extract]) this.cache.add(data[this.extract], data);
+  // forward original
+  if (this.bypass) this.emit('data', data);
+};
+
+exports.create = function() {
+  return new FilterCacheloop();
+};

--- a/lib/filters/filter_cacheloop.js
+++ b/lib/filters/filter_cacheloop.js
@@ -8,12 +8,12 @@ function FilterCacheloop() {
   base_filter.BaseFilter.call(this);
   this.mergeConfig({
     name: 'CacheLoop',
-    optional_params: ['cacheSize','cacheAge','extract'],
+    optional_params: ['cacheSize','cacheAge','extract','groupBy','mean','bypass'],
     default_values: {
       'cacheSize': 5000,
       'cacheAge': 10000,
       'extract': 'correlation_id',
-      'bypass': false
+      'bypass': true,
     },
     start_hook: this.start,
   });
@@ -23,7 +23,8 @@ util.inherits(FilterCacheloop, base_filter.BaseFilter);
 
 FilterCacheloop.prototype.start = function(callback) {
   logger.info('Initialized Drop Filter');
-  this.onStale = function(data){
+  var onStale = function(data){
+    logger.info('processing stales...',data);
     for (let [key, value] of data.records.entries()) {
       var records = []; var output = {};
       value.list.forEach(function(row){
@@ -31,15 +32,17 @@ FilterCacheloop.prototype.start = function(callback) {
       });
       if (records.length == 0||!records.length) return;
       output[key] = records;
-      this.emit('data',output);
+      this.emit('output',output);
     }
   }.bind(this);
+  onStale = onStale;
 
-  this.cache = recordCache({
+  var cache = recordCache({
     maxSize: this.cacheSize,
     maxAge: this.cacheAge,
-    onStale: this.onStale
-  }.bind(this));
+    onStale: onStale
+  });
+  this.cache = cache;
 
   callback();
 };
@@ -48,7 +51,7 @@ FilterCacheloop.prototype.process = function(data) {
   // cache by extraction
   if (data[this.extract]) this.cache.add(data[this.extract], data);
   // forward original
-  if (this.bypass) this.emit('data', data);
+  if (this.bypass) this.emit('output', data);
 };
 
 exports.create = function() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pastash",
   "description": "Spaghetti I/O Processing, Interpolation, Correlation and beyond - nodejs logstash + beat",
-  "version": "1.0.26",
+  "version": "1.0.28",
   "author": "Lorenzo Mangani <lorenzo.mangani@gmail.com>",
   "contributors": [
     {


### PR DESCRIPTION
The cacheloop filter can be injected in a pipeline to aggregate records with common parameters, such as CDRs aggregated by a correlation ID or message flows aggregated by protocol, implemented as an LRU emitting stale events and optionally passing-through when duplication of records is desirable.