### PR TITLE
ES output to use Content-Type app json

### DIFF
--- a/lib/outputs/output_elasticsearch.js
+++ b/lib/outputs/output_elasticsearch.js
@@ -52,6 +52,9 @@ OutputElasticSearch.prototype.postData = function(path, data) {
     port: this.port,
     method: 'POST',
     path: path,
+    headers: {
+       'Content-Type': 'application/json'
+    }
   };
 
   this.sendHttpRequest(params, data);


### PR DESCRIPTION
Adding `Content-Type` header to ES output, mandatory from ES 6.x.