### PR TITLE
manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ sudo npm install -g pastash
   * Centos system: `yum install gcc gcc-c++ make`
 * Install zmq dev libraries: This is required to build the [node zeromq module](https://github.com/JustinTulloss/zeromq.node).
   * Debian based system: `apt-get install libzmq1`. Under recent releases, this package is present in default repositories. On ubuntu lucid, use this [ppa](https://launchpad.net/~chris-lea/+archive/zeromq). On debian squeeze, use [backports](http://backports-master.debian.org/Instructions/).
-  * Centos 6: `yum install zeromq zeromq-devel`. First, you have to add the rpm zeromq repo : `curl http://download.opensuse.org/repositories/home:/fengshuo:/zeromq/CentOS_CentOS-6/home:fengshuo:zeromq.repo > /etc/yum.repos.d/zeromq.repo`
+  * Centos 6: First, add the zeromq repo : `curl https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/CentOS_6/network:messaging:zeromq:release-stable.repo > /etc/yum.repos.d/zeromq-centos6.repo`. 
+  Then `yum install zeromq zeromq-devel`. 
+  * CentOS 7: First, add the zeromq repo : `curl https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/CentOS_7/network:messaging:zeromq:release-stable.repo > /etc/yum.repos.d/zeromq-centos7.repo`.
+  Then `yum install zeromq zeromq-devel`. 
 * Clone repository: `git clone git://github.com/sipcapture/pastash.git && cd pastash`
 * Install dependencies: `npm install`.
 


### PR DESCRIPTION
Install instructions are broken. The CentOS repo does not exist at the documented location.  

Even instructions at the website are wrong:
http://zeromq.org/distro:centos

Perhaps these ones?

CentOS 7
https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/CentOS_7/network:messaging:zeromq:release-stable.repo

CentOS 6
https://download.opensuse.org/repositories/network:/messaging:/zeromq:/release-stable/CentOS_6/network:messaging:zeromq:release-stable.repo

Other download locations available here (you may have luck with deb stuff, I don't know what it should look like, I don't often run deb or ubu nowadays):

https://build.opensuse.org/project/show/network:messaging:zeromq:release-stable