### PR TITLE
Update output_hep.js

### DIFF
--- a/lib/outputs/output_hep.js
+++ b/lib/outputs/output_hep.js
@@ -41,7 +41,7 @@ OutputHep.prototype.preHep = function(data) {
 		logger.debug('PRE-PACKED HEP JSON!');
 		data.rcinfo.captureId = this.hep_id;
 		data.rcinfo.capturePass = this.hep_pass;
-		return hepjs.encapsulate(data.payload,data.rcinfo);
+		return hepjs.encapsulate(JSON.stringify(data.payload),data.rcinfo);
 	  };
 
 	  // Default HEP RCINFO


### PR DESCRIPTION
fix instance of Object passing to function instead of string or an instance of Buffer, ArrayBuffer, or Array. String chosen.

Was getting error when sending prepacked json encapsulated "rcinfo" and "payload" HEP.
_"ERROR PREHEP ERROR: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object"._

this fixed an error and was able to successfully send JSON HEP over network 