### PR TITLE
Sonus Syslog Fixes for missing newlines

### DIFF
--- a/plugins/filters/app_sonus/filter_app_sonuslog.js
+++ b/plugins/filters/app_sonus/filter_app_sonuslog.js
@@ -74,8 +74,8 @@ FilterAppSonusLog.prototype.process = function(data) {
    var line = data.message;
 
    if (line.indexOf('sent msg for CallId') !== -1) {
-	   var regex = /<147> [0-9] (.*)(?:usec| USEC)(.*?)sent msg for CallId:(.*) to IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)RAW PDU:#012(.*)/g;
-	   if (this.type == 1) regex = /.*<147> [0-9] (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d?\.\d+?[+-]\d\d:\d\d|Z) (.*)msg for CallId:(.*) to IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)#012.*RAW PDU:#012(.*)/g;
+	   var regex = /<147> [0-9] (.*)(?:usec| USEC)(.*?)sent msg for CallId:(.*) to IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)RAW PDU:#012(.*)(<147>)?/g;
+	   if (this.type == 1) regex = /.*<147> [0-9] (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d?\.\d+?[+-]\d\d:\d\d|Z) (.*)msg for CallId:(.*) to IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)#012.*RAW PDU:#012(.*)(<147>)?/g;
 	   var ip = regex.exec(line);
 	   if (!ip) { logger.error(line); return; }
 	   ipcache = {};
@@ -95,8 +95,8 @@ FilterAppSonusLog.prototype.process = function(data) {
 	   this.postProcess();
 
    } else if (line.indexOf('received msg for CallId') !== -1) {
-	   var regex = /<147> [0-9] (.*)(?:usec| USEC)(.*?)received msg for CallId:(.*) from IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)RAW PDU:#012(.*)/g;
-	   if (this.type == 1) regex = /.*<147> [0-9] (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d?\.\d+?[+-]\d\d:\d\d|Z) (.*)msg for CallId:(.*) from IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)#012.*RAW PDU:#012(.*)/g;
+	   var regex = /<147> [0-9] (.*)(?:usec| USEC)(.*?)received msg for CallId:(.*) from IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)RAW PDU:#012(.*)(<147>)?/g;
+	   if (this.type == 1) regex = /.*<147> [0-9] (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d?\.\d+?[+-]\d\d:\d\d|Z) (.*)msg for CallId:(.*) from IP\/port:(.*)\/(.*), Local IP\/port:(.*)\/(.*), SMM:(.*)#012.*RAW PDU:#012(.*)(<147>)?/g;
 	   var ip = regex.exec(line);
 	   if (!ip) { logger.error(line); return; }
 	   logger.log('receive',ipcache);

--- a/plugins/filters/app_sonus/package.json
+++ b/plugins/filters/app_sonus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pastash/filter_app_sonuslog",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Sonus TRC Filter Plugin for @pastash/pastash",
   "main": "filter_app_sonuslog.js",
   "scripts": {


### PR DESCRIPTION
This patch is an attempted fix for the Sonus Syslog receiver bug where newlines at the end of certain messages are missing.