### PR TITLE
Fix amqp reconnect function timeout handling

### DIFF
--- a/lib/outputs/output_amqp.js
+++ b/lib/outputs/output_amqp.js
@@ -119,11 +119,11 @@ OutputAmqp.prototype.publish = function(message,options){
 
 OutputAmqp.prototype.reconnect = function() {
   let self = this;
-  setTimeout(()=>{
+  self.reconnectTimeoutId = setTimeout(() => {
     self.connect().then(() => {
-      clearTimeout(self.reconnect);
+      clearTimeout(self.reconnectTimeoutId);
     }).catch((err) => console.error(err));
-  },self.retry_delay);
+  }, self.retry_delay);
 };
 
 OutputAmqp.prototype.connect = function(){


### PR DESCRIPTION
* use a dedicated timeout ID variable to manage and clear the reconnection timeout
* this prevents stacked reconnection attempts by ensuring the timeout is cleared on successful reconnect