### PR TITLE
added support for 7.40A.500+, output_hep detect object and turn into …

### DIFF
--- a/lib/outputs/output_hep.js
+++ b/lib/outputs/output_hep.js
@@ -1,94 +1,105 @@
 var abstract_udp = require('./abstract_udp'),
-  hepjs = require('hep-js'),
-  util = require('util'),
-  logger = require('log4node');
+	hepjs = require('hep-js'),
+	util = require('util'),
+	logger = require('log4node')
 
 function OutputHep() {
-  abstract_udp.AbstractUdp.call(this);
-  this.mergeConfig({
-    name: 'Udp',
-  });
-  this.mergeConfig(this.serializer_config());
-  this.mergeConfig({
-    name: 'HEP/EEP Server',
-    optional_params: ['hep_id', 'hep_pass', 'hep_cid', 'hep_type', 'src_ip', 'src_port', 'dst_ip', 'dst_port', 'hep_payload_type', 'hep_ip_family', 'hep_protocol', 'transaction_type'],
-    default_values: {
-      host: '127.0.0.1',
-      port: 9063,
-      hep_id: '2001',
-      hep_pass: 'MyHep',
-      hep_cid: '#{correlation_id}',
-      hep_type: 100,
-      hep_payload_type: 1,
-      hep_ip_family: 1,
-      hep_protocol: 17,
-      src_ip: '127.0.0.1',
-      src_port: '0',
-      dst_ip: '127.0.0.2',
-      dst_port: '0',
-      hep_timefield: false
-    },
-  });
+	abstract_udp.AbstractUdp.call(this);
+	this.mergeConfig({
+		name: 'Udp',
+	});
+	this.mergeConfig(this.serializer_config());
+	this.mergeConfig({
+		name: 'HEP/EEP Server',
+		optional_params: ['hep_id', 'hep_pass', 'hep_cid', 'hep_type', 'src_ip', 'src_port', 'dst_ip', 'dst_port', 'hep_payload_type', 'hep_ip_family', 'hep_protocol', 'transaction_type'],
+		default_values: {
+		host: '127.0.0.1',
+		port: 9063,
+		hep_id: '2001',
+		hep_pass: 'MyHep',
+		hep_cid: '#{correlation_id}',
+		hep_type: 100,
+		hep_payload_type: 1,
+		hep_ip_family: 1,
+		hep_protocol: 17,
+		src_ip: '127.0.0.1',
+		src_port: '0',
+		dst_ip: '127.0.0.2',
+		dst_port: '0',
+		hep_timefield: false
+		},
+	})
 }
 
 util.inherits(OutputHep, abstract_udp.AbstractUdp);
 
 OutputHep.prototype.preHep = function(data) {
+	try {
+		// IF HEP JSON
+		if (data.rcinfo && data.payload) {
+			logger.debug('PRE-PACKED HEP JSON!');
+			data.rcinfo.captureId = this.hep_id;
+			data.rcinfo.capturePass = this.hep_pass;
+			/* Detect if an object was passed to payload, then transform payload to string */
+			if (typeof data.payload == 'object') {
+				data.payload = JSON.stringify(data.payload)
+			}
+			return hepjs.encapsulate(data.payload,data.rcinfo);
+		}
 
-  try {
-	  // IF HEP JSON
-	  if (data.rcinfo && data.payload) {
-		logger.debug('PRE-PACKED HEP JSON!');
-		data.rcinfo.captureId = this.hep_id;
-		data.rcinfo.capturePass = this.hep_pass;
-		return hepjs.encapsulate(JSON.stringify(data.payload),data.rcinfo);
-	  };
+		// Default HEP RCINFO
+		var hep_proto = {
+			'type': 'HEP',
+			'version': 3,
+			'payload_type': this.hep_payload_type,
+			'proto_type': this.hep_type,
+			'captureId': this.hep_id,
+			'capturePass': this.hep_pass,
+			'ip_family': this.hep_ip_family,
+			'protocol': this.hep_protocol
+		}
+		
+		var datenow = new Date();
+		hep_proto.time_sec = data.time_sec || Math.floor(datenow.getTime() / 1000);
+		hep_proto.time_usec = data.time_usec || datenow.getMilliseconds() * 1000;
+		// Build HEP3 w/ null network parameters - TBD configurable
+		hep_proto.srcIp = data.srcIp || this.src_ip;
+		hep_proto.dstIp = data.dstIp || this.dst_ip;
+		hep_proto.srcPort = data.srcPort || this.src_port;
+		hep_proto.dstPort = data.dstPort || this.dst_port;
+		// pair correlation id from pattern
+		hep_proto.correlation_id = data.correlation_id || '';
+		// Optional Transaction Type
+		if (this.transaction_type) { hep_proto.transaction_type = this.transaction_type; }
 
-	  // Default HEP RCINFO
-	  var hep_proto = {
-	    'type': 'HEP',
-	    'version': 3,
-	    'payload_type': this.hep_payload_type,
-	    'proto_type': this.hep_type,
-	    'captureId': this.hep_id,
-	    'capturePass': this.hep_pass,
-	    'ip_family': this.hep_ip_family,
-	    'protocol': this.hep_protocol
-	  };
-	  
-  	var datenow = new Date();
-	hep_proto.time_sec = data.time_sec || Math.floor(datenow.getTime() / 1000);
-	hep_proto.time_usec = data.time_usec || datenow.getMilliseconds() * 1000;
-	// Build HEP3 w/ null network parameters - TBD configurable
-  	hep_proto.srcIp = data.srcIp || this.src_ip;
-  	hep_proto.dstIp = data.dstIp || this.dst_ip;
-  	hep_proto.srcPort = data.srcPort || this.src_port;
-  	hep_proto.dstPort = data.dstPort || this.dst_port;
-  	// pair correlation id from pattern
-	hep_proto.correlation_id = data.correlation_id || '';
-	// Optional Transaction Type
-	if (this.transaction_type) { hep_proto.transaction_type = this.transaction_type; }
-	  
-	if (data.payload) {
-	    // Pack HEP3
-	    return hepjs.encapsulate(JSON.stringify(data.payload),hep_proto);
- 	} else {
-	    // Pack HEP3 Log Type fallback
-	    hep_proto.payload_type = 100;
-	    return hepjs.encapsulate(JSON.stringify(data),hep_proto);
-        }
+		if (data.payload) {
+			// Pack HEP3
+			/* Detect if an object was passed to payload, then transform payload to string */
+			if (typeof data.payload == 'object') {
+				data.payload = JSON.stringify(data.payload)
+			}
+			return hepjs.encapsulate(data.payload,hep_proto);
+		} else {
+			// Pack HEP3 Log Type fallback
+			hep_proto.payload_type = 100;
+			/* Detect if an object was passed to data, then transform data to string */
+			if (typeof data == 'object') {
+				data = JSON.stringify(data)
+			}
+			return hepjs.encapsulate(JSON.stringify(data),hep_proto);
+			}
 
-   } catch(e) { logger.error('PREHEP ERROR:',e); }
-};
+	} catch(e) { logger.error('PREHEP ERROR:',e); }
+}
 
 OutputHep.prototype.formatPayload = function(data, callback) {
-  if (data) callback(this.preHep(data));
-};
+  if (data) callback(this.preHep(data))
+}
 
 OutputHep.prototype.to = function() {
-  return 'HEP udp to ' + this.host + ':' + this.port;
-};
+  return 'HEP udp to ' + this.host + ':' + this.port
+}
 
 exports.create = function() {
-  return new OutputHep();
-};
+  return new OutputHep()
+}

--- a/plugins/filters/app_audiocodes/filter_app_audiocodes.js
+++ b/plugins/filters/app_audiocodes/filter_app_audiocodes.js
@@ -4,100 +4,103 @@
 */
 
 var base_filter = require('@pastash/pastash').base_filter,
-  util = require('util'),
-  logger = require('@pastash/pastash').logger;
+	util = require('util'),
+	logger = require('@pastash/pastash').logger
 
-var fs = require('fs')
-  , ini = require('ini')
+var fs = require('fs'), 
+	ini = require('ini')
 
-var moment = require('moment');
-var LRU = require("lru-cache")
-  , sidcache = new LRU(1000)
-  , expire = 10000 * 60 * 60
+var moment = require('moment')
+var LRU = require("lru-cache"), 
+	sidcache = new LRU(1000),
+	expire = 10000 * 60 * 60
 
 function FilterAppAudiocodes() {
-  base_filter.BaseFilter.call(this);
-  this.mergeConfig({
-    name: 'AppAudiocodes',
-    optional_params: ['correlation_hdr','bypass', 'debug', 'logs', 'localip', 'localport', 'correlation_contact', 'qos', 'autolocal', 'version', 'ini', 'iniwatch'],
-    default_values: {
-      'correlation_contact': false,
-      'correlation_hdr': false,
-      'debug': false,
-      'bypass': false,
-      'logs': false,
-      'qos': true,
-      'autolocal': false,
-      'localip': '127.0.0.1',
-      'localport': 5060,
-      'version': '7.20A.260.012',
-      'ini': false,
-      'iniwatch': false
-    },
-    start_hook: this.start,
-  });
+  	base_filter.BaseFilter.call(this);
+  	this.mergeConfig({
+    	name: 'AppAudiocodes',
+		optional_params: ['correlation_hdr','bypass', 'debug', 'file_debug', 'logs', 'localip', 'localport', 'correlation_contact', 'qos', 'autolocal', 'version', 'ini', 'iniwatch'],
+		default_values: {
+			'correlation_contact': false,
+			'correlation_hdr': false,
+			'debug': false,
+			'file_debug': false,
+			'bypass': false,
+			'logs': false,
+			'qos': true,
+			'autolocal': false,
+			'localip': '127.0.0.1',
+			'localport': 5060,
+			'version': '7.20A.260.012',
+			'ini': false,
+			'iniwatch': false
+    	},
+    	start_hook: this.start,
+ 	});
 }
 
 util.inherits(FilterAppAudiocodes, base_filter.BaseFilter);
 
 FilterAppAudiocodes.prototype.start = function(callback) {
-logger.info('Initialized App Audiocodes SysLog to SIP/HEP parser');
-  if (this.ini){
-	logger.info('Reading INI file to resolver...', this.ini);
-	try {
-	  this.resolver = parseIni(this.ini);
-          logger.info('INI Loaded '+this.resolver.interfaces.lenght +' Interfaces');
-          logger.info('INI Loaded '+this.resolver.sip.lenght +' SIP Profiles');
-	  if (this.debug) console.log(this.resolver);
-	  if (this.iniwatch) watchIni(this.ini, this.resolver);
-	} catch(err) { logger.error(err) }
-  }
+	logger.info('Initialized App Audiocodes SysLog to SIP/HEP parser');
+  	if (this.ini){
+		logger.info('Reading INI file to resolver...', this.ini);
+		try {
+			this.resolver = parseIni(this.ini);
+			logger.info('INI Loaded '+this.resolver.interfaces.lenght +' Interfaces');
+			logger.info('INI Loaded '+this.resolver.sip.lenght +' SIP Profiles');
+			if (this.debug) console.log(this.resolver);
+			if (this.iniwatch) watchIni(this.ini, this.resolver);
+		} catch(err) { logger.error(err) }
+ 	}
 
-  this.postProcess = function(ipcache,last,type){
-	 if(!last||!ipcache) return;
-   	 last = last.replace(/#012/g, '\r\n').trim() + "\r\n\r\n";
-         var rcinfo = {
-              type: 'HEP',
-              version: 3,
-              payload_type: type ? 'LOG' :'SIP',
-              ip_family: 2,
-              protocol: 17,
-              proto_type: type || 1,
-              correlation_id: ipcache.callId || '',
-              srcIp: ipcache.srcIp || this.localip,
-              srcPort: ipcache.srcPort || 0,
-              dstIp: ipcache.dstIp || this.localip,
-              dstPort: ipcache.dstPort || 0,
-              time_sec: ipcache.ts || parseInt(new Date().getTime() / 1000),
-              time_usec: ipcache.usec || new Date().getMilliseconds()
-            };
+  	this.postProcess = function(ipcache,last,type){
+	 	if(!last||!ipcache) return;
+   		last = last.replace(/#012/g, '\r\n').trim() + "\r\n\r\n";
+        var rcinfo = {
+			type: 'HEP',
+			version: 3,
+			payload_type: type ? 'LOG' :'SIP',
+			ip_family: 2,
+			protocol: 17,
+			proto_type: type || 1,
+			correlation_id: ipcache.callId || '',
+			srcIp: ipcache.srcIp || this.localip,
+			srcPort: ipcache.srcPort || 0,
+			dstIp: ipcache.dstIp || this.localip,
+			dstPort: ipcache.dstPort || 0,
+			time_sec: ipcache.ts || parseInt(new Date().getTime() / 1000),
+			time_usec: ipcache.usec || new Date().getMilliseconds()
+		};
 
-	 // EXTRACT CORRELATION HEADER, IF ANY
-	  if (this.correlation_hdr && rcinfo.proto_type == 1 && last.startsWith('INVITE')) {
+		// EXTRACT CORRELATION HEADER, IF ANY
+		if (this.correlation_hdr && rcinfo.proto_type == 1 && last.startsWith('INVITE')) {
           	var xcid = last.match(this.correlation_hdr+":\s?(.*)\r\n\r\n");
-               	if (xcid && xcid[1]) rcinfo.correlation_id = xcid[1].trim();
-                        if (this.debug) logger.info('auto correlation pick', rcinfo.correlation_id);
-         }
-
-	 if (this.correlation_contact && rcinfo.proto_type == 1 && last.startsWith('INVITE')) {
-		var extract = /x-c=(.*?)\//.exec(last);
-		if (extract[1]) {
-			rcinfo.correlation_id = extract[1];
-			if (this.debug) logger.info('auto correlation pick', rcinfo.correlation_id);
+            if (xcid && xcid[1]) rcinfo.correlation_id = xcid[1].trim();
+            if (this.debug) logger.info('auto correlation pick', rcinfo.correlation_id);
 		}
-	 }
 
-	 if (last.indexOf('2.0/TCP') !== -1 || last.indexOf('2.0/TLS') !== -1 ){
-		rcinfo.protocol = 6;
-		if (this.autolocal) rcinfo.dstPort = 5061;
-         }
+	 	if (this.correlation_contact && rcinfo.proto_type == 1 && last.startsWith('INVITE')) {
+			var extract = /x-c=(.*?)\//.exec(last);
+			if (extract[1]) {
+				rcinfo.correlation_id = extract[1];
+				if (this.debug) logger.info('auto correlation pick', rcinfo.correlation_id);
+			}
+	 	}
 
-         if (last && rcinfo) {
-           var data = { payload: last, rcinfo: rcinfo };
-	   return data;
-         }
-  }
-  callback();
+	 	if (last.indexOf('2.0/TCP') !== -1 || last.indexOf('2.0/TLS') !== -1 ){
+			rcinfo.protocol = 6;
+			if (this.autolocal) rcinfo.dstPort = 5061;
+        }
+
+        if (last && rcinfo) {
+          	var data = { payload: last, rcinfo: rcinfo };
+			console.log('FINAL DATA')
+			console.log(data.payload)
+	   		return data;
+        }
+  	}
+  	callback();
 };
 
 var last = '';
@@ -111,17 +114,31 @@ var seq;
 FilterAppAudiocodes.prototype.process = function(data) {
 
    var line = data.message.toString();
+   if (this.file_debug) {
+	console.log('RECEIVED LINE')
+	console.log(JSON.stringify(line))
+	line = line.replace(/\\n/g, '\n')
+	line = line.replace(/\\r/g, '\r')
+	line = line.replace(/"/g, '')
+	line = line.replace(/\\\"/g, '\"')
+	console.log('Fixed Line from File Input to syslog input')
+	console.log(line)
+   }
    var ipcache = {};
    if (this.debug) console.info('DEBUG', line);
-   var message = /^.*?\[S=([0-9]+)\].*?\[SID=.*?\]\s?(.*)\[Time:.*\]$/
+   if (this.version === '7.40A.500') {
+	var message = /.*\[S=([0-9]+)\].*?\[SID=.*?\]\s?(.*)\[Time:.*\]/g
+   } else {
+	var message = /^.*?\[S=([0-9]+)\].*?\[SID=.*?\]\s?(.*)\[Time:.*\]$/
+   }
    var test = message.exec(line.replace(/\r\n/g, '#012'));
    if(hold && line && test) {
-        if (this.debug) logger.error('Next packet number', test[1]);
+        if (this.debug) logger.error('Next packet number', test[1])
         if (parseInt(test[1]) == seq + 1) {
-	  line = cache + ( test ? test[2] : '');
-	  hold = false;
-	  cache = '';
-	  if (this.debug) console.info('reassembled line', line);
+			line = cache + ( test ? test[2] : '')
+			hold = false
+			cache = ''
+			if (this.debug) console.info('reassembled line', line)
         }
    }
 
@@ -130,270 +147,273 @@ FilterAppAudiocodes.prototype.process = function(data) {
    var ids = /\[SID=(?<mac>.*?):(?<seq>.*?):(?<sid>.*?)\]/.exec(line) || [];
    if (this.debug) logger.error('SESSION SID',ids[3]);
 
-   if (line.indexOf('Incoming SIP Message') !== -1) {
-      try {
-	   // var regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*--- #012(.*)#012 #012 #012(.*) \[Time:(.*)-(.*)@(.*)\]/g;
-           var regex;
-	   if (this.version == '7.20A.256.511') {
-                regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*---  (.*)(.*)/g; //7.20A.256.511
-	   } else {
-                regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*---\s?#012(.*)#012\s?#012(.*)/g; //7.20A.260.012
-	   }
-
-	   if (this.resolver){
-	   	var aliasregex = /SIPInterface #([^\s]+) \((.*)\) (.*) TO/g;
-	   	var interface = aliasregex.exec(line) || false;
-	   	if (this.resolver && interface){
-			var alias = interface[1]; //0
-			var group = interface[2]; //some-group
-			var proto = interface[3]; //UDP,TCP,TLS
-
-			var ifname = this.resolver.sip[group] ? this.resolver.sip[group].NetworkInterface : false;
-			if (ifname){
-			  var xlocalip = this.resolver.ifs[ifname] ? this.resolver.ifs[ifname] : false;
-			  var xlocalport = this.resolver.sip[group] ? this.resolver.sip[group][proto+"Port"] : false;
-			  if (this.debug) console.log('!!!!!!!!!!!!!!!!! IN IFNAME MATCH', group, ifname, alias, proto, xlocalip, xlocalport);
+	if (line.indexOf('Incoming SIP Message') !== -1) {
+		try {
+			// var regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*--- #012(.*)#012 #012 #012(.*) \[Time:(.*)-(.*)@(.*)\]/g;
+			var regex;
+			if (this.version === '7.40A.500') {
+				regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO\(#[0-99]\) ----  (.*)/g; //7.40A.500.357
+			} else if (this.version == '7.20A.256.511') {
+				regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*---  (.*)(.*)/g; //7.20A.256.511
 			} else {
-			  if (this.debug) console.log('!!!!!!!!!!!!!!!!! IN IFNAME FAILURE', group, ifname, alias, proto);
+				regex = /(.*)---- Incoming SIP Message from (.*) to SIPInterface #[0-99] \((.*)\) (.*) TO.*---\s?#012(.*)#012\s?#012(.*)/g; //7.20A.260.012
 			}
-	   	}
-	   }
 
-	   var ip = regex.exec(line);
-	   if (!ip) {
-		cache = line.replace(/\[Time.*\]$/,'');
-		hold = true;
-                var regpackid = /.*\[S=([0-9]+)\].*/.exec(line);
-                seq = parseInt(regpackid[1]);
-                if (this.debug) logger.error('Crashed packet number', seq, line);
-		logger.error('failed parsing Incoming SIP. Cache on!');
-		if (this.bypass) return data;
-	   } else {
-                   if (xlocalip && xlocalport){
-			   ipcache.dstIp = xlocalip;
-			   ipcache.dstPort = parseInt(xlocalport);
-		   } else if (ip[3]) {
-			   /* convert alias to IP:port */
-			   ipcache.dstIp = aliases[0] || this.localip;
-			   ipcache.dstPort = aliases[1] || this.localport;
-		   }
-		   ipcache.srcIp = ip[2].split(':')[0];
-		   ipcache.srcPort = ip[2].split(':')[1];
-		   last = ip[5];
-	   	   last += '#012 #012';
-		   var callid = last.match(/call-id:\s?(.*?)\s?#012/i) || [];
-		   ipcache.callId = callid[1] || ids[3] || '';
-		   // Cache SID to Call-ID correlation
-		   sidcache.set(ids[3], ipcache.callid, expire);
-		   // Seek final fragment
-		   if(ip[6].includes(' SIP Message ')){
-			hold = true;
-			cache = line.replace(/\[Time.*\]$/,'');
-		   }
-		   return this.postProcess(ipcache,last);
-	   }
-     } catch(e) { logger.error(e, line); }
+			if (this.resolver){
+				var aliasregex = /SIPInterface #([^\s]+) \((.*)\) (.*) TO/g;
+				var interface = aliasregex.exec(line) || false;
+				if (this.resolver && interface){
+					var alias = interface[1]; //0
+					var group = interface[2]; //some-group
+					var proto = interface[3]; //UDP,TCP,TLS
 
-   } else if (line.indexOf('Outgoing SIP Message') !== -1) {
-      try {
-           var regex;
-           if (this.version == '7.20A.256.511') {
-	        regex = /(.*)---- Outgoing SIP Message to (.*) from SIPInterface #[0-99] \((.*)\) (.*) TO.*---  (.*)(.*)/g; //7.20A.256.511
-           } else {
-                regex = /(.*)---- Outgoing SIP Message to (.*) from SIPInterface #[0-99] \((.*)\) (.*) TO.*---\s?#012(.*)#012\s?#012 (.*)/g; //7.20A.260.012
-           }
+					var ifname = this.resolver.sip[group] ? this.resolver.sip[group].NetworkInterface : false;
+					if (ifname){
+						var xlocalip = this.resolver.ifs[ifname] ? this.resolver.ifs[ifname] : false;
+						var xlocalport = this.resolver.sip[group] ? this.resolver.sip[group][proto+"Port"] : false;
+						if (this.debug) console.log('!!!!!!!!!!!!!!!!! IN IFNAME MATCH', group, ifname, alias, proto, xlocalip, xlocalport);
+					} else {
+						if (this.debug) console.log('!!!!!!!!!!!!!!!!! IN IFNAME FAILURE', group, ifname, alias, proto);
+					}
+				}
+			}
 
-	   if (this.resolver){
-	   	var aliasregex = /SIPInterface #([^\s]+) \((.*)\) (.*) TO/g;
-	   	var interface = aliasregex.exec(line) || false;
-	   	if (this.resolver && interface){
-			var alias = interface[1]; //0
-			var group = interface[2]; //some-group
-			var proto = interface[3]; //UDP,TCP,TLS
-
-			var ifname = this.resolver.sip[group] ? this.resolver.sip[group].NetworkInterface : false;
-			if (ifname){
-			  var xlocalip = this.resolver.ifs[ifname] ? this.resolver.ifs[ifname] : false;
-			  var xlocalport = this.resolver.sip[group] ? this.resolver.sip[group][proto+"Port"] : false;
-			  if (this.debug) console.log('!!!!!!!!!!!!!!!!! OUT IFNAME MATCH', group, ifname, alias, proto, xlocalip, xlocalport);
+			var ip = regex.exec(line);
+			if (!ip) {
+				cache = line.replace(/\[Time.*\]$/,'');
+				hold = true;
+				var regpackid = /.*\[S=([0-9]+)\].*/.exec(line);
+				seq = parseInt(regpackid[1]);
+				if (this.debug) logger.error('Cached packet number', seq, line);
+				logger.error('failed parsing Incoming SIP. Cache on!');
+				if (this.bypass) return data;
 			} else {
-			  if (this.debug) console.log('!!!!!!!!!!!!!!!!! OUT IFNAME FAILURE', group, ifname, alias, proto);
+				if (xlocalip && xlocalport){
+					ipcache.dstIp = xlocalip;
+					ipcache.dstPort = parseInt(xlocalport);
+				} else if (ip[3]) {
+					/* convert alias to IP:port */
+					ipcache.dstIp = aliases[0] || this.localip;
+					ipcache.dstPort = aliases[1] || this.localport;
+				}
+				ipcache.srcIp = ip[2].split(':')[0];
+				ipcache.srcPort = ip[2].split(':')[1];
+				last = ip[5];
+				last += '#012 #012';
+				var callid = last.match(/call-id:\s?(.*?)\s?#012/i) || [];
+				ipcache.callId = callid[1] || ids[3] || '';
+				// Cache SID to Call-ID correlation
+				sidcache.set(ids[3], ipcache.callId, expire);
+				// Seek final fragment
+				if(ip[6]?.includes(' SIP Message ') && this.version !== '7.40A.500'){
+					hold = true;
+					cache = line.replace(/\[Time.*\]$/,'');
+				}
+				return this.postProcess(ipcache,last);
 			}
-	   	}
-	   }
+		} catch(e) { 
+			logger.error(e, line); 
+		}
 
-	   var ip = regex.exec(line);
-	   if (!ip) {
-		cache = line.replace(/\[Time.*\]$/,'');
-		hold = true;
-                var regpackid = /.*\[S=([0-9]+)\].*/.exec(line);
-                seq = parseInt(regpackid[1]);
-                if (this.debug) logger.error('Cashed packet number', seq, line);
-		logger.error('failed parsing Outgoing SIP. Cache on!');
+   	} else if (line.indexOf('Outgoing SIP Message') !== -1) {
+      	try {
+           	var regex;
+			if (this.version === '7.40A.500') {
+				regex = /(.*) ---- Outgoing SIP Message to (.*) from SIPInterface #[0-99] \((.*)\) (.*) TO\(#.*\) ----  (.*)/g; //7.40A.500.357
+			} else if (this.version == '7.20A.256.511') {
+				regex = /(.*)---- Outgoing SIP Message to (.*) from SIPInterface #[0-99] \((.*)\) (.*) TO.*---  (.*)(.*)/g; //7.20A.256.511
+			} else {
+					regex = /(.*)---- Outgoing SIP Message to (.*) from SIPInterface #[0-99] \((.*)\) (.*) TO.*---\s?#012(.*)#012\s?#012 (.*)/g; //7.20A.260.012
+			}
+
+			if (this.resolver) {
+				var aliasregex = /SIPInterface #([^\s]+) \((.*)\) (.*) TO/g;
+				var interface = aliasregex.exec(line) || false;
+				if (this.resolver && interface) {
+					var alias = interface[1]; //0
+					var group = interface[2]; //some-group
+					var proto = interface[3]; //UDP,TCP,TLS
+
+					var ifname = this.resolver.sip[group] ? this.resolver.sip[group].NetworkInterface : false;
+					if (ifname) {
+						var xlocalip = this.resolver.ifs[ifname] ? this.resolver.ifs[ifname] : false;
+						var xlocalport = this.resolver.sip[group] ? this.resolver.sip[group][proto+"Port"] : false;
+						if (this.debug) console.log('!!!!!!!!!!!!!!!!! OUT IFNAME MATCH', group, ifname, alias, proto, xlocalip, xlocalport);
+					} else {
+						if (this.debug) console.log('!!!!!!!!!!!!!!!!! OUT IFNAME FAILURE', group, ifname, alias, proto);
+					}
+				}
+	   		}
+
+	   		var ip = regex.exec(line);
+	   		if (!ip) {
+				cache = line.replace(/\[Time.*\]$/,'');
+				hold = true;
+				var regpackid = /.*\[S=([0-9]+)\].*/.exec(line);
+				seq = parseInt(regpackid[1]);
+				if (this.debug) logger.error('Cached packet number', seq, line);
+				logger.error('failed parsing Outgoing SIP. Cache on!');
+				if (this.bypass) return data;
+	   		} else {
+				if (xlocalip && xlocalport){
+					ipcache.srcIp = xlocalip;
+					ipcache.srcPort = parseInt(xlocalport);
+				} else if (ip[3]) {
+					/* convert alias to IP:port */
+					ipcache.srcIp = aliases[0] || this.localip;
+					ipcache.srcPort = aliases[1] || this.localport;
+				}
+				ipcache.dstIp = ip[2].split(':')[0];
+				ipcache.dstPort = ip[2].split(':')[1];
+				last = ip[5];
+				last += '#012 #012';
+				var callid = last.match(/call-id:\s?(.*?)\s?#012/i) || [];
+				ipcache.callId = callid[1] || ids[3] || '';
+				// Cache SID to Call-ID correlation
+				sidcache.set(ids[3], ipcache.callId, expire);
+				// Seek final fragment
+				if(ip[6]?.includes(' SIP Message ') && this.version !== '7.40A.500'){
+					hold = true;
+					cache = line.replace(/\[Time.*\]$/,'');
+				}
+				return this.postProcess(ipcache,last);
+	   		}
+    	} catch(e) { 
+			logger.error(e, line); 
+		}
+   	} else if (this.autolocal && line.indexOf('Local IP Address =') !== -1) {
+		var local = line.match(/Local IP Address = (.*?):(.*?),/) || [];
+		if(local[1]) this.localip   = local[1];
+		if(local[2]) this.localport = local[2];
+   	} else if (line.indexOf('CALL_END ') !== -1 && this.logs) {
+		// Parser TBD page 352 @ https://www.audiocodes.com/media/10312/ltrt-41548-mediant-software-sbc-users-manual-ver-66.pdf
+		var cdr = line.split(/(\s+\|)/).filter( function(e) { return e.trim().length > 1; } )
+		ipcache.callId = cdr[3] || '';
+		if (this.debug) logger.info('CALL_END', cdr, ipcache);
+		if (this.logs) return this.postProcess(ipcache,JSON.stringify(cdr),100);
+	} else if (line.indexOf('MEDIA_END ') !== -1 && this.qos) {
+		// Parsed TBD page 353 @ https://www.audiocodes.com/media/10312/ltrt-41548-mediant-software-sbc-users-manual-ver-66.pdf
+		var qos = line.split(/(\s+\|)/).filter( function(e) { return e.trim().length > 1; } )
+		if (qos.length == 25){
+			qos.splice(15, 1);
+			qos.splice(5, 1);
+		}
+		logger.info('!!!!!!!!!!!!!! DEBUG MEDIA', qos, qos.length);
+		if(qos && qos[2] && qos[21]){
+			ipcache.callId = qos[2] || '';
+			var response = [];
+			// A-LEG
+			ipcache.srcIp = qos[7];
+			ipcache.srcPort = parseInt(qos[8]);
+			ipcache.dstIp = qos[9];
+			ipcache.dstPort = parseInt(qos[10]);
+			var local_report = {
+				"CORRELATION_ID": qos[2],
+				"RTP_SIP_CALL_ID": qos[2],
+				"MOS": 4.5 * parseInt(qos[17]) / 127,
+				"TOTAL_PK": parseInt(qos[11]),
+				"CODEC_NAME": qos[5],
+				"DIR":0,
+				"REPORT_NAME": qos[4] + "_" + qos[7] + ":" + qos[8],
+				"PARTY":0,
+				"TYPE":"HANGUP"
+			};
+			response.push(this.postProcess(ipcache,JSON.stringify(local_report),35));
+			// B-LEG
+			ipcache.srcIp = qos[9];
+			ipcache.srcPort = parseInt(qos[10]);
+			ipcache.dstIp = qos[7];
+			ipcache.dstPort = parseInt(qos[8]);
+			var remote_report = {
+				"CORRELATION_ID": qos[2],
+				"RTP_SIP_CALL_ID": qos[2],
+				"MOS": 4.5 * parseInt(qos[18]) / 127,
+				"TOTAL_PK": parseInt(qos[12]),
+				"CODEC_NAME": qos[5],
+				"DIR":1,
+				"REPORT_NAME": qos[4] + "_" + qos[9] + ":" + qos[10],
+				"PARTY":1,
+				"TYPE":"HANGUP"
+			};
+			response.push(this.postProcess(ipcache,JSON.stringify(remote_report),35));
+			if (this.debug) logger.info('MEDIA_END', response);
+			if (this.qos) return response;
+		} else {
+			logger.error('missing media parameters', qos);
+		}
+	} else if (ids[3] && !hold && this.logs) {
 		if (this.bypass) return data;
-	   } else {
-                   if (xlocalip && xlocalport){
-			   ipcache.srcIp = xlocalip;
-			   ipcache.srcPort = parseInt(xlocalport);
-		   } else if (ip[3]) {
-			   /* convert alias to IP:port */
-			   ipcache.srcIp = aliases[0] || this.localip;
-			   ipcache.srcPort = aliases[1] || this.localport;
-		   }
-		   ipcache.dstIp = ip[2].split(':')[0];
-		   ipcache.dstPort = ip[2].split(':')[1];
-		   last = ip[5];
-	   	   last += '#012 #012';
-		   var callid = last.match(/call-id:\s?(.*?)\s?#012/i) || [];
-		   ipcache.callId = callid[1] || ids[3] || '';
-		   // Cache SID to Call-ID correlation
-		   sidcache.set(ids[3], ipcache.callid, expire);
-		   // Seek final fragment
-		   if(ip[6].includes(' SIP Message ')){
-			hold = true;
-			cache = line.replace(/\[Time.*\]$/,'');
-		   }
-		   return this.postProcess(ipcache,last);
-	   }
-     } catch(e) { logger.error(e, line); }
-
-   } else if (this.autolocal && line.indexOf('Local IP Address =') !== -1) {
-	var local = line.match(/Local IP Address = (.*?):(.*?),/) || [];
-	if(local[1]) this.localip   = local[1];
-	if(local[2]) this.localport = local[2];
-   } else if (line.indexOf('CALL_END ') !== -1 && this.logs) {
-	// Parser TBD page 352 @ https://www.audiocodes.com/media/10312/ltrt-41548-mediant-software-sbc-users-manual-ver-66.pdf
-	var cdr = line.split(/(\s+\|)/).filter( function(e) { return e.trim().length > 1; } )
-	ipcache.callId = cdr[3] || '';
-	if (this.debug) logger.info('CALL_END', cdr, ipcache);
-	if (this.logs) return this.postProcess(ipcache,JSON.stringify(cdr),100);
-
-   } else if (line.indexOf('MEDIA_END ') !== -1 && this.qos) {
-	// Parsed TBD page 353 @ https://www.audiocodes.com/media/10312/ltrt-41548-mediant-software-sbc-users-manual-ver-66.pdf
-	var qos = line.split(/(\s+\|)/).filter( function(e) { return e.trim().length > 1; } )
-	if (qos.length == 25){
-		qos.splice(15, 1);
-		qos.splice(5, 1);
-	}
-	logger.info('!!!!!!!!!!!!!! DEBUG MEDIA', qos, qos.length);
-	if(qos && qos[2] && qos[21]){
-		ipcache.callId = qos[2] || '';
-		var response = [];
-		// A-LEG
-		ipcache.srcIp = qos[7];
-		ipcache.srcPort = parseInt(qos[8]);
-		ipcache.dstIp = qos[9];
-		ipcache.dstPort = parseInt(qos[10]);
-		var local_report = {
-			"CORRELATION_ID": qos[2],
-			"RTP_SIP_CALL_ID": qos[2],
-			"MOS": 4.5 * parseInt(qos[17]) / 127,
-			"TOTAL_PK": parseInt(qos[11]),
-			"CODEC_NAME": qos[5],
-			"DIR":0,
-			"REPORT_NAME": qos[4] + "_" + qos[7] + ":" + qos[8],
-			"PARTY":0,
-			"TYPE":"HANGUP"
-		};
-		response.push(this.postProcess(ipcache,JSON.stringify(local_report),35));
-		// B-LEG
-		ipcache.srcIp = qos[9];
-		ipcache.srcPort = parseInt(qos[10]);
-		ipcache.dstIp = qos[7];
-		ipcache.dstPort = parseInt(qos[8]);
-		var remote_report = {
-			"CORRELATION_ID": qos[2],
-			"RTP_SIP_CALL_ID": qos[2],
-			"MOS": 4.5 * parseInt(qos[18]) / 127,
-			"TOTAL_PK": parseInt(qos[12]),
-			"CODEC_NAME": qos[5],
-			"DIR":1,
-			"REPORT_NAME": qos[4] + "_" + qos[9] + ":" + qos[10],
-			"PARTY":1,
-			"TYPE":"HANGUP"
-		};
-		response.push(this.postProcess(ipcache,JSON.stringify(remote_report),35));
-		if (this.debug) logger.info('MEDIA_END', response);
-		if (this.qos) return response;
+		// Prepare SIP LOG
+		if (this.logs) {
+			ipcache.callId = sidcache.get(ids[3]) || ids[3] || '';
+			ipcache.srcIp = this.localip || '127.0.0.1';
+			ipcache.srcPort = 514
+			ipcache.dstIp = this.localip || '127.0.0.1';
+			ipcache.dstPort = 514
+			return this.postProcess(ipcache,line,100);
+		}
 	} else {
-		logger.error('missing media parameters', qos);
+		// Discard
+		if (this.bypass) return data;
 	}
-
-   } else if (ids[3] && !hold && this.logs) {
-	if (this.bypass) return data;
-	// Prepare SIP LOG
-	if (this.logs) {
-		ipcache.callId = sidcache.get(ids[3]) || ids[3] || '';
-		ipcache.srcIp = this.localip || '127.0.0.1';
-		ipcache.srcPort = 514
-		ipcache.dstIp = this.localip || '127.0.0.1';
-		ipcache.dstPort = 514
-		return this.postProcess(ipcache,line,100);
-	}
-   } else {
-	// Discard
-	if (this.bypass) return data;
-   }
 };
 
 exports.create = function() {
-  return new FilterAppAudiocodes();
+	return new FilterAppAudiocodes();
 };
 
 
 
 const watchIni = function(filePath, ini){
-  logger.info('Watching INI for changes...',filePath);
-  fs.watch(filePath, (event, filename) => {
-    if (filename && event ==='change'){
-      console.log('INI file Changed! Reloading...', filename);
-      ini = parseIni(filePath);
-    }
-  });
+	logger.info('Watching INI for changes...',filePath);
+	fs.watch(filePath, (event, filename) => {
+		if (filename && event ==='change'){
+			console.log('INI file Changed! Reloading...', filename);
+			ini = parseIni(filePath);
+		}
+	});
 }
 
 const parseIni = function(filePath){
+	var config = ini.parse(fs.readFileSync(filePath, 'utf-8'))
 
-  var config = ini.parse(fs.readFileSync(filePath, 'utf-8'))
+	var interface = config.InterfaceTable;
+	var interface_index = interface['FORMAT Index'].split(', '); delete interface['FORMAT Index'];
+	var interface_obj = {};
+	var count = 0;
+	Object.entries(interface).forEach(entry => {
+		const [key, value] = entry;
+		var values = value.split(', ');
+		interface_obj[count] = {};
+		values.forEach(function(val, link){
+			interface_obj[count][interface_index[link]] = val.replace(/^["'](.+(?=["']$))["']$/, '$1');
+		});
+		count++;
+	});
 
-  var interface = config.InterfaceTable;
-  var interface_index = interface['FORMAT Index'].split(', '); delete interface['FORMAT Index'];
-  var interface_obj = {};
-  var count = 0;
-  Object.entries(interface).forEach(entry => {
-    const [key, value] = entry;
-    var values = value.split(', ');
-    interface_obj[count] = {};
-    values.forEach(function(val, link){
-          interface_obj[count][interface_index[link]] = val.replace(/^["'](.+(?=["']$))["']$/, '$1');
-    });
-    count++;
-  });
+	var ifs = {};
+	Object.entries(interface_obj).forEach(entry => {
+		ifs[entry[1].InterfaceName] = entry[1].IPAddress;
+	});
 
-  var ifs = {};
-  Object.entries(interface_obj).forEach(entry => {
-	ifs[entry[1].InterfaceName] = entry[1].IPAddress;
-  });
-
-  var sipinterface = config.SIPInterface;
-  var sipinterface_index = sipinterface['FORMAT Index'].split(', '); delete sipinterface['FORMAT Index'];
-  var sipinterface_obj = {};
-  var count = 0;
-  Object.entries(sipinterface).forEach(entry => {
-    const [key, value] = entry;
-    var values = value.split(', ');
-    var realm = values[0].replace(/^["'](.+(?=["']$))["']$/, '$1'); delete values[0];
-    sipinterface_obj[realm] = {};
-    values.forEach(function(val, link){
-        sipinterface_obj[realm][sipinterface_index[link]] = val.replace(/^["'](.+(?=["']$))["']$/, '$1');
-    });
-    count++;
-  });
+	var sipinterface = config.SIPInterface;
+	var sipinterface_index = sipinterface['FORMAT Index'].split(', '); delete sipinterface['FORMAT Index'];
+	var sipinterface_obj = {};
+	var count = 0;
+	Object.entries(sipinterface).forEach(entry => {
+		const [key, value] = entry;
+		var values = value.split(', ');
+		var realm = values[0].replace(/^["'](.+(?=["']$))["']$/, '$1'); delete values[0];
+		sipinterface_obj[realm] = {};
+		values.forEach(function(val, link){
+			sipinterface_obj[realm][sipinterface_index[link]] = val.replace(/^["'](.+(?=["']$))["']$/, '$1');
+		});
+		count++;
+	});
 
 
-  if (this.debug) logger.info('INI Interfaces', interface_obj);
-  if (this.debug) logger.info('INI SIP Interfaces', sipinterface_obj);
+	if (this.debug) logger.info('INI Interfaces', interface_obj);
+	if (this.debug) logger.info('INI SIP Interfaces', sipinterface_obj);
 
-  return { interfaces: interface_obj, sip: sipinterface_obj, ifs: ifs }
-
+	return { interfaces: interface_obj, sip: sipinterface_obj, ifs: ifs }
 }

--- a/plugins/filters/app_audiocodes/package.json
+++ b/plugins/filters/app_audiocodes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pastash/filter_app_audiocodes",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Audiocodes Syslog plugin for @pastash/pastash",
   "main": "filter_app_audiocodes.js",
   "scripts": {

--- a/plugins/filters/app_audiocodes/readme.md
+++ b/plugins/filters/app_audiocodes/readme.md
@@ -10,6 +10,7 @@ This example recipe parse, reassemble and convert Audiocodes SBC logs back into 
 
 #### Dependencies
 * Audiocodes Mediant SBC
+  * 7.40A.500 _(or higher)_
   * 7.20A.260.012 _(or higher)_
   * 7.20A.256.511 _(or lower)_
 * NodeJS 10.x+ and paStash need to be installed before execution
@@ -85,7 +86,8 @@ Parameters for `app_audiocodes`:
 * `correlation_hdr`: SIP Header to use for correlation IDs. Default : false.
 * `correlation_contact`: Auto-Extract correlation from Contact x-c. Default : false.
 * `debug`: Enable debug logs. Default : false.
-* `version`: Syslog parser version. Supports `7.20A.260.012` _(or higher)_. Default: 7.20A.260.012
+* `file_debug`: Enable debug using file input. (For development) Default : false.
+* `version`: Syslog parser version. Supports `7.40A.500` _(or higher)_. Default: 7.20A.260.012
 
 For full instructions consult the [plugin documentation](https://github.com/sipcapture/paStash/blob/next/plugins/filters/app_audiocodes/app_audiocodes.md)
 


### PR DESCRIPTION
* Added the necessary changes to support 7.40A.500.000 and later in the filter_app_audiocodes plugin.
* Checking type inside output HEP to detect objects that need to be transformed into string before being sent. Normal strings will no longer pass through JSON.stringify before being sent. (Some capture servers do not expect escape symbols in the payload)