### PR TITLE
Fix missing return for CDR messages in filter HSP

### DIFF
--- a/plugins/filters/app_hsp/filter_app_hsp.js
+++ b/plugins/filters/app_hsp/filter_app_hsp.js
@@ -192,7 +192,7 @@ FilterAppHsp.prototype.process = function(raw) {
 				  }
 				}
 			}
-
+			return raw.message;
 	    }  else { return raw.message; }
 
 	} catch(e) { console.log('ERROR:',e); return raw.message; }


### PR DESCRIPTION
Fixes #241. A return was mistakenly removed, so that now this filter will fail to process any CDR-type messages (or, at least, won't pass them through the filter).

Re-adding the return got us back up and running in our CDR-handling environment.